### PR TITLE
Added openSUSE to the list of community packages

### DIFF
--- a/data/get/os.yaml
+++ b/data/get/os.yaml
@@ -11,6 +11,10 @@
   Description: "Manjaro Budgie is a community spin of Manjaro with Budgie."
   BudgieVersion: "10.2.8"
   URL: "https://forum.manjaro.org/t/manjaro-budgie-16-10/12316"
+"openSUSE":
+  Description: "Budgie packages for openSUSE Leap and Tumbleweed"
+  BudgieVersion: "10.2.9"
+  URL: "https://software.opensuse.org/package/budgie-desktop"
 "Ubuntu Budgie":
   Description: "Ubuntu Budgie is community spin of Ubuntu with Budgie."
   BudgieVersion: "10.2.9"


### PR DESCRIPTION
As @ikeydoherty already made a pretty high quality thirdparty package there was just a few things to clean up https://build.opensuse.org/request/show/452888 and prepare for an inclusion in the official distribution https://build.opensuse.org/request/show/452889 which will hopefully be accepted soon.

Also updated https://en.opensuse.org/Budgie accordingly.