### PR TITLE
Fix github.com source URL

### DIFF
--- a/themes/budgie/layouts/partials/navigation/get.html
+++ b/themes/budgie/layouts/partials/navigation/get.html
@@ -4,6 +4,6 @@
 	{{ partial "get/banner.html" (dict "site" $site "ismenu" "true") }}
 	<div data-budgie-component="fancy-get-nav-links">
 		<a href="{{ $site.BaseURL }}get">Other OSes</a>
-		<a href="https://github.com/budgie-desktop">Source</a>
+		<a href="https://github.com/solus-project/budgie-desktop">Source</a>
 	</div>
 </div>


### PR DESCRIPTION
The link to the source on github.com is broken.